### PR TITLE
feat: `chain-id` and `l2 chain-id` cmds

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -30,6 +30,8 @@ pub(crate) struct CLI {
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
+    #[clap(subcommand, about = "L2 specific commands.")]
+    L2(l2::Command),
     #[clap(subcommand, about = "Generate shell completion scripts.")]
     Autocomplete(autocomplete::Command),
     #[clap(about = "Get the current block_number.", visible_alias = "bl")]
@@ -109,8 +111,18 @@ pub(crate) enum Command {
         #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
         rpc_url: String,
     },
-    #[clap(subcommand, about = "L2 specific commands.")]
-    L2(l2::Command),
+    #[clap(about = "Get the network's chain id.")]
+    ChainId {
+        #[arg(
+            short,
+            long,
+            default_value_t = false,
+            help = "Display the chain id as a hex-string."
+        )]
+        hex: bool,
+        #[arg(default_value = "http://localhost:8545", env = "RPC_URL")]
+        rpc_url: String,
+    },
 }
 
 impl Command {
@@ -298,6 +310,17 @@ impl Command {
 
                 if !args.background {
                     wait_for_transaction_receipt(tx_hash, &client, 100).await?;
+                }
+            }
+            Command::ChainId { hex, rpc_url } => {
+                let eth_client = EthClient::new(&rpc_url);
+
+                let chain_id = eth_client.get_chain_id().await?;
+
+                if hex {
+                    println!("{chain_id:#x}");
+                } else {
+                    println!("{chain_id}");
                 }
             }
         };

--- a/cli/src/commands/l2.rs
+++ b/cli/src/commands/l2.rs
@@ -205,6 +205,18 @@ pub(crate) enum Command {
         )]
         rpc_url: String,
     },
+    #[clap(about = "Get the network's chain id.")]
+    ChainId {
+        #[arg(
+            short,
+            long,
+            default_value_t = false,
+            help = "Display the chain id as a hex-string."
+        )]
+        hex: bool,
+        #[arg(default_value = "http://localhost:1729", env = "RPC_URL")]
+        rpc_url: String,
+    },
 }
 
 impl Command {
@@ -363,6 +375,9 @@ impl Command {
             }
             Command::Deploy { args, rpc_url } => {
                 Box::pin(async { EthCommand::Deploy { args, rpc_url }.run().await }).await?
+            }
+            Command::ChainId { hex, rpc_url } => {
+                Box::pin(async { EthCommand::ChainId { hex, rpc_url }.run().await }).await?
             }
         };
         Ok(())


### PR DESCRIPTION
**`l2 chain-id`**

```Shell
Get the network's chain id.

Usage: ethertools-cli l2 chain-id [OPTIONS] [RPC_URL]

Arguments:
  [RPC_URL]  [env: RPC_URL=] [default: http://localhost:1729]

Options:
  -h, --hex   Display the chain id as a hex-string.
  -h, --help  Print help
```

**`chain-id`**

```Shell
Get the network's chain id.

Usage: ethertools-cli chain-id [OPTIONS] [RPC_URL]

Arguments:
  [RPC_URL]  [env: RPC_URL=] [default: http://localhost:8545]

Options:
  -h, --hex   Display the chain id as a hex-string.
  -h, --help  Print help
```