### PR TITLE
Improve `address` cmd

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -78,11 +78,11 @@ pub(crate) enum Command {
         visible_aliases = ["addr", "a"]
     )]
     Address {
-        #[arg(long, value_parser = parse_private_key, conflicts_with_all = ["zero", "random"], required_unless_present_any = ["zero", "random"], env = "PRIVATE_KEY")]
+        #[arg(long, value_parser = parse_private_key, conflicts_with_all = ["zero", "random"], required_unless_present_any = ["zero", "random"], env = "PRIVATE_KEY", help = "The private key to derive the address from.")]
         from_private_key: Option<SecretKey>,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["from_private_key", "random"], required_unless_present_any = ["from_private_key", "random"])]
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["from_private_key", "random"], required_unless_present_any = ["from_private_key", "random"], help = "The zero address.")]
         zero: bool,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["from_private_key", "zero"], required_unless_present_any = ["from_private_key", "zero"])]
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["from_private_key", "zero"], required_unless_present_any = ["from_private_key", "zero"], help = "A random address.")]
         random: bool,
     },
     #[clap(about = "Transfer funds to another wallet.")]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -4,7 +4,7 @@ use crate::{
     common::{CallArgs, DeployArgs, SendArgs, TransferArgs},
     utils::parse_private_key,
 };
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 use ethertools_sdk::{
     balance_in_eth,
     client::{EthClient, Overrides, eth::get_address_from_secret_key},
@@ -74,12 +74,16 @@ pub(crate) enum Command {
         rpc_url: String,
     },
     #[clap(
-        about = "Get the account's address from private key.",
+        about = "Get either the account's address from private key, the zero address, or a random address",
         visible_aliases = ["addr", "a"]
     )]
     Address {
-        #[arg(value_parser = parse_private_key, env = "PRIVATE_KEY")]
-        private_key: SecretKey,
+        #[arg(long, value_parser = parse_private_key, conflicts_with_all = ["zero", "random"], required_unless_present_any = ["zero", "random"], env = "PRIVATE_KEY")]
+        from_private_key: Option<SecretKey>,
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["from_private_key", "random"], required_unless_present_any = ["from_private_key", "random"])]
+        zero: bool,
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["from_private_key", "zero"], required_unless_present_any = ["from_private_key", "zero"])]
+        random: bool,
     },
     #[clap(about = "Transfer funds to another wallet.")]
     Transfer {
@@ -168,8 +172,20 @@ impl Command {
 
                 println!("{nonce}");
             }
-            Command::Address { private_key } => {
-                let address = get_address_from_secret_key(&private_key)?;
+            Command::Address {
+                from_private_key,
+                zero,
+                random,
+            } => {
+                let address = if let Some(private_key) = from_private_key {
+                    get_address_from_secret_key(&private_key)?
+                } else if zero {
+                    Address::zero()
+                } else if random {
+                    Address::random()
+                } else {
+                    return Err(eyre::Error::msg("No option provided"));
+                };
 
                 println!("{address:#x}");
             }


### PR DESCRIPTION
**TLDR**

```
Get either the account's address from private key, the zero address, or a random address

Usage: ethertools-cli address [OPTIONS]

Options:
      --from-private-key <FROM_PRIVATE_KEY>
          The private key to derive the address from. [env: PRIVATE_KEY=]
  -z, --zero
          The zero address.
  -r, --random
          A random address.
  -h, --help
          Print help
```

**Examples**

```Shell
cargo run --release -- address -z
cargo run --release -- address --zero

0x0000000000000000000000000000000000000000
```

```Shell
cargo run --release -- address -r
cargo run --release -- address --random

0xacbd16ef03fdbb747e7124c23a396f7670c8f77d
```


```Shell
cargo run --release -- address --from-private-key 0xe75fae0065403d4091f3d6549c4219db69c96d9de761cfc75fe9792b6166c758

0x14eff6e0bcc07363ee55d30d0a0e86386be1ca54
```