### PR TITLE
Hash cmd

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -84,7 +84,7 @@ pub(crate) enum Command {
         private_key: SecretKey,
     },
     #[clap(
-        about = "Get either the keccak for a given input, the zero hash, or a random hash",
+        about = "Get either the keccak for a given input, the zero hash, the empty string, or a random hash",
         visible_alias = "h"
     )]
     Hash {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -88,12 +88,14 @@ pub(crate) enum Command {
         visible_alias = "h"
     )]
     Hash {
-        #[arg(long, value_parser = parse_hex, conflicts_with_all = ["zero", "random"], required_unless_present_any = ["zero", "random"], env = "INPUT", help = "The input to hash.")]
+        #[arg(long, value_parser = parse_hex, conflicts_with_all = ["zero", "random", "string"], required_unless_present_any = ["zero", "random"], env = "INPUT", help = "The input to hash.")]
         input: Option<Bytes>,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "random"], required_unless_present_any = ["input", "random"], help = "The zero address.")]
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "random", "string"], required_unless_present_any = ["input", "random"], help = "The zero hash.")]
         zero: bool,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "zero"], required_unless_present_any = ["input", "zero"], help = "A random address.")]
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "zero", "string"], required_unless_present_any = ["input", "zero"], help = "A random hash.")]
         random: bool,
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "zero", "random"], required_unless_present_any = ["input", "zero"], help = "Hash of empty string")]
+        string: bool,
     },
     #[clap(about = "Transfer funds to another wallet.")]
     Transfer {
@@ -191,6 +193,7 @@ impl Command {
                 input,
                 zero,
                 random,
+                string,
             } => {
                 let hash = if let Some(input) = input {
                     keccak(&input)
@@ -198,6 +201,8 @@ impl Command {
                     H256::zero()
                 } else if random {
                     H256::random()
+                } else if string {
+                    keccak(b"")
                 } else {
                     return Err(eyre::Error::msg("No option provided"));
                 };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -88,13 +88,13 @@ pub(crate) enum Command {
         visible_alias = "h"
     )]
     Hash {
-        #[arg(long, value_parser = parse_hex, conflicts_with_all = ["zero", "random", "string"], required_unless_present_any = ["zero", "random"], env = "INPUT", help = "The input to hash.")]
+        #[arg(long, value_parser = parse_hex, conflicts_with_all = ["zero", "random", "string"], required_unless_present_any = ["zero", "random", "string"], env = "INPUT", help = "The input to hash.")]
         input: Option<Bytes>,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "random", "string"], required_unless_present_any = ["input", "random"], help = "The zero hash.")]
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "random", "string"], required_unless_present_any = ["input", "random", "string"], help = "The zero hash.")]
         zero: bool,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "zero", "string"], required_unless_present_any = ["input", "zero"], help = "A random hash.")]
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "zero", "string"], required_unless_present_any = ["input", "zero", "string"], help = "A random hash.")]
         random: bool,
-        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "zero", "random"], required_unless_present_any = ["input", "zero"], help = "Hash of empty string")]
+        #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "zero", "random"], required_unless_present_any = ["input", "zero", "random"], help = "Hash of empty string")]
         string: bool,
     },
     #[clap(about = "Transfer funds to another wallet.")]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -88,7 +88,7 @@ pub(crate) enum Command {
         visible_alias = "h"
     )]
     Hash {
-        #[arg(long, value_parser = parse_hex, conflicts_with_all = ["zero", "random", "string"], required_unless_present_any = ["zero", "random", "string"], env = "INPUT", help = "The input to hash.")]
+        #[arg(long, value_parser = parse_hex, conflicts_with_all = ["zero", "random", "string"], required_unless_present_any = ["zero", "random", "string"], help = "The input to hash.")]
         input: Option<Bytes>,
         #[arg(short, long, action = ArgAction::SetTrue, conflicts_with_all = ["input", "random", "string"], required_unless_present_any = ["input", "random", "string"], help = "The zero hash.")]
         zero: bool,


### PR DESCRIPTION
**TLDR**

```Shell
Get either the keccak for a given input, the zero hash, empty string, or a random hash

Usage: ethertools-cli hash [OPTIONS]

Options:
      --input <INPUT>  The input to hash.
  -z, --zero           The zero hash.
  -r, --random         A random hash.
  -s, --string         Hash of empty string
  -h, --help           Print help
```

**Examples**

```Shell
cargo run --release -- hash --random
cargo run --release -- hash -r

0x742ea87bb4454efcac204d46258f1834ee9385c7922b870cf4ef3dd95ca5dd63
```


```Shell
cargo run --release -- hash --zero
cargo run --release -- hash -z

0x0000000000000000000000000000000000000000000000000000000000000000
```


```Shell
cargo run --release -- hash --input 0xe75fae0065403d4091f3d6549c4219db69c96d9de761cfc75fe9792b6166c758

0x374ee32410e98bc2e0480eba0d8378cd12b3d858a0bc7f8a1961ca47b37c4e88
```

```Shell
cargo run --release -- hash --string
cargo run --release -- hash -s

0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
```